### PR TITLE
samples: add Kafka auth audit logging to Bookinfo productpage.py

### DIFF
--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -5,4 +5,5 @@ flask_bootstrap
 json2html
 simplejson
 gevent
+kafka-python
 


### PR DESCRIPTION
Add logging of every login and logout into the Bookinfo sample's `productpage.py` using Kafka.
Add command-line option `--kafka-bootstrap-server` to pass the Kafka bootstrap server used to initialize the Kafka producer.